### PR TITLE
Share blink delay between pico and pico_w versions

### DIFF
--- a/blink/blink.c
+++ b/blink/blink.c
@@ -6,6 +6,8 @@
 
 #include "pico/stdlib.h"
 
+#include "blink.h"
+
 #define PICO_DEFAULT_LED_PIN 25
 
 int main() {
@@ -17,9 +19,9 @@ int main() {
     gpio_set_dir(LED_PIN, GPIO_OUT);
     while (true) {
         gpio_put(LED_PIN, 1);
-        sleep_ms(50);
+        sleep_ms(BLINK_DELAY);
         gpio_put(LED_PIN, 0);
-        sleep_ms(50);
+        sleep_ms(BLINK_DELAY);
     }
 #endif
 }

--- a/blink/blink.h
+++ b/blink/blink.h
@@ -1,0 +1,3 @@
+#ifndef BLINK_DELAY
+#define BLINK_DELAY 100
+#endif

--- a/blink/picow_blink.c
+++ b/blink/picow_blink.c
@@ -7,6 +7,8 @@
 #include "pico/stdlib.h"
 #include "pico/cyw43_arch.h"
 
+#include "blink.h"
+
 int main() {
     stdio_init_all();
     if (cyw43_arch_init()) {
@@ -15,8 +17,8 @@ int main() {
     }
     while (true) {
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 1);
-        sleep_ms(250);
+        sleep_ms(BLINK_DELAY);
         cyw43_arch_gpio_put(CYW43_WL_GPIO_LED_PIN, 0);
-        sleep_ms(250);
+        sleep_ms(BLINK_DELAY);
     }
 }


### PR DESCRIPTION
## Changes

Add header to centrally define the blink delay.

## Use

Makes the delay consistent between the `w` and non `w` pico variant and easier to change.